### PR TITLE
Proposed changes for &mut Command and minor QoL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "interactive_process"
 version = "0.1.2"
-edition = "2018"
+edition = "2021"
 authors = ["Paul Butler <paulgb@gmail.com>"]
 repository = "https://github.com/paulgb/interactive_process"
 license = "MIT OR Apache-2.0"

--- a/examples/bash.rs
+++ b/examples/bash.rs
@@ -8,8 +8,8 @@ use interactive_process::InteractiveProcess;
 use std::{process::Command, thread::sleep, time::Duration};
 
 fn main() {
-    let cmd = Command::new("/usr/bin/bash");
-    let mut proc = InteractiveProcess::new(cmd, |line| {
+    let mut cmd = Command::new("/usr/bin/bash");
+    let mut proc = InteractiveProcess::new(&mut cmd, |line| {
         println!("Got: {}", line.unwrap());
     })
     .unwrap();

--- a/examples/closing_stream.py
+++ b/examples/closing_stream.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 
-def main():
-    print('h1')
-    print('h2')
 
-if __name__ == '__main__':
+def main():
+    print("h1")
+    print("h2")
+
+
+if __name__ == "__main__":
     main()

--- a/examples/closing_stream.rs
+++ b/examples/closing_stream.rs
@@ -2,9 +2,9 @@ use interactive_process::InteractiveProcess;
 use std::process::Command;
 
 fn main() {
-    let cmd = Command::new("examples/closing_stream.py");
+    let mut cmd = Command::new("examples/closing_stream.py");
     let proc = InteractiveProcess::new_with_exit_callback(
-        cmd,
+        &mut cmd,
         |line| {
             println!("Got: {}", line.unwrap());
         },

--- a/examples/echo_stream.py
+++ b/examples/echo_stream.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 
+
 def main():
     while True:
         line = input()
-        if line == 'exit':
+        if line == "exit":
             break
         print(f"echo: {line}", flush=True)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/examples/echo_stream.rs
+++ b/examples/echo_stream.rs
@@ -2,8 +2,8 @@ use interactive_process::InteractiveProcess;
 use std::{process::Command, thread::sleep, time::Duration};
 
 fn main() {
-    let cmd = Command::new("examples/echo_stream.py");
-    let mut proc = InteractiveProcess::new(cmd, |line| {
+    let mut cmd = Command::new("examples/echo_stream.py");
+    let mut proc = InteractiveProcess::new(&mut cmd, |line| {
         println!("Got: {}", line.unwrap());
     })
     .unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ impl InteractiveProcess {
     /// standard in and out streams for later use. The provided callback is
     /// called for every newline-terminated string written to `stdout` by the
     /// process.
-    pub fn new<T>(command: Command, line_callback: T) -> Result<Self>
+    pub fn new<T>(command: &mut Command, line_callback: T) -> Result<Self>
     where
         T: Fn(Result<String>) + Send + 'static,
     {
@@ -49,7 +49,7 @@ impl InteractiveProcess {
     /// Constructor with the same semantics as `new`, except that an additional
     /// no-argument closure is provided which is called when the client exits.
     pub fn new_with_exit_callback<T, S>(
-        mut command: Command,
+        command: &mut Command,
         line_callback: T,
         exit_callback: S,
     ) -> std::io::Result<Self>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //! with a [std::io::Result]-wrapped [String] for each string received from the
 //! child process. Upon construction, [InteractiveProcess] begins executing the
 //! passed command and starts the event loop. Whilst the process is running, you
-//! can send 
+//! can send
 
 use std::io::{BufRead, BufReader, Result, Write};
 use std::process::{Child, ChildStdin, Command, ExitStatus, Stdio};


### PR DESCRIPTION
Closes #2

Here are a couple small changes I have made. Happy to drop any parts you're not interested in.

- Pass the command argument as `&mut Command` to be slightly more idiomatic
- Bump the edition to 2021
- Apply formatting to the repository(Python's Black and Rust's rustfmt)